### PR TITLE
oc fixes

### DIFF
--- a/hack/update-generated-clientsets.sh
+++ b/hack/update-generated-clientsets.sh
@@ -49,6 +49,6 @@ fi
 for pkg in "${packages[@]}"; do
   shortGroup=$(basename "${pkg}")
   containingPackage=$(dirname "${pkg}")
-  generate_clientset_for "${containingPackage}" "internalclientset"  --group=${shortGroup} --input=${shortGroup} ${verify} "$@"
-  generate_clientset_for "${containingPackage}" "clientset" --group=${shortGroup} --version=v1 --input=${shortGroup}/v1 ${verify} "$@"
+  generate_clientset_for "${containingPackage}" "internalclientset"  --input=${shortGroup} ${verify} "$@"
+  generate_clientset_for "${containingPackage}" "clientset" --input=${shortGroup}/v1 ${verify} "$@"
 done

--- a/pkg/oc/admin/diagnostics/cluster.go
+++ b/pkg/oc/admin/diagnostics/cluster.go
@@ -106,9 +106,9 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 		case clustdiags.ClusterRouterName:
 			d = &clustdiags.ClusterRouter{KubeClient: kclusterClient, DCClient: appsClient.Apps()}
 		case clustdiags.ClusterRolesName:
-			d = &clustdiags.ClusterRoles{ClusterRolesClient: oauthorizationClient.ClusterRoles(), SARClient: kclusterClient.Authorization()}
+			d = &clustdiags.ClusterRoles{ClusterRolesClient: oauthorizationClient.Authorization().ClusterRoles(), SARClient: kclusterClient.Authorization()}
 		case clustdiags.ClusterRoleBindingsName:
-			d = &clustdiags.ClusterRoleBindings{ClusterRoleBindingsClient: oauthorizationClient.ClusterRoleBindings(), SARClient: kclusterClient.Authorization()}
+			d = &clustdiags.ClusterRoleBindings{ClusterRoleBindingsClient: oauthorizationClient.Authorization().ClusterRoleBindings(), SARClient: kclusterClient.Authorization()}
 		case clustdiags.MetricsApiProxyName:
 			d = &clustdiags.MetricsApiProxy{KubeClient: kclusterClient}
 		case clustdiags.ServiceExternalIPsName:

--- a/pkg/oc/admin/node/node_options.go
+++ b/pkg/oc/admin/node/node_options.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	kapi "k8s.io/kubernetes/pkg/api"
-	externalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	kprinters "k8s.io/kubernetes/pkg/printers"
@@ -26,7 +26,7 @@ import (
 
 type NodeOptions struct {
 	DefaultNamespace   string
-	ExternalKubeClient externalclientset.Interface
+	ExternalKubeClient kubernetes.Interface
 	KubeClient         kclientset.Interface
 	Writer             io.Writer
 	ErrWriter          io.Writer
@@ -64,7 +64,7 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	if err != nil {
 		return err
 	}
-	externalkc, err := externalclientset.NewForConfig(config)
+	externalkc, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/bootstrap/docker/openshift/import.go
+++ b/pkg/oc/bootstrap/docker/openshift/import.go
@@ -15,7 +15,7 @@ import (
 // ImportObjects imports objects into OpenShift from a particular location
 // into a given namespace
 func ImportObjects(f *clientcmd.Factory, ns, location string) error {
-	schema, err := f.Validator(false, "")
+	schema, err := f.Validator(false, false, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/cmd/cancelbuild.go
+++ b/pkg/oc/cli/cmd/cancelbuild.go
@@ -144,7 +144,7 @@ func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 
 	o.Namespace = namespace
 	o.Client = client
-	o.BuildLister = buildclient.NewClientBuildLister(client)
+	o.BuildLister = buildclient.NewClientBuildLister(client.Build())
 	o.BuildClient = client.Build().Builds(namespace)
 	o.Mapper, _ = f.Object()
 

--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/kubectl/util/term"
 	"k8s.io/kubernetes/pkg/util/interrupt"
-	"k8s.io/kubernetes/pkg/util/term"
 
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"

--- a/pkg/oc/cli/cmd/login/helpers.go
+++ b/pkg/oc/cli/cmd/login/helpers.go
@@ -16,7 +16,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kterm "k8s.io/kubernetes/pkg/util/term"
+	kterm "k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	"github.com/openshift/origin/pkg/cmd/util/term"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"

--- a/pkg/oc/cli/cmd/login/login.go
+++ b/pkg/oc/cli/cmd/login/login.go
@@ -14,7 +14,7 @@ import (
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/term"
+	"k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"

--- a/pkg/oc/cli/cmd/login/loginoptions.go
+++ b/pkg/oc/cli/cmd/login/loginoptions.go
@@ -18,7 +18,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kterm "k8s.io/kubernetes/pkg/util/term"
+	kterm "k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"

--- a/pkg/oc/cli/cmd/login/util/util.go
+++ b/pkg/oc/cli/cmd/login/util/util.go
@@ -21,7 +21,7 @@ func CanRequestProjects(config *restclient.Config, defaultNamespace string) (boo
 		},
 	}
 
-	listResponse, err := oClient.SubjectAccessReviews().Create(sar)
+	listResponse, err := oClient.Authorization().SubjectAccessReviews().Create(sar)
 	if err != nil {
 		return false, err
 	}
@@ -34,7 +34,7 @@ func CanRequestProjects(config *restclient.Config, defaultNamespace string) (boo
 		},
 	}
 
-	createResponse, err := oClient.SubjectAccessReviews().Create(sar)
+	createResponse, err := oClient.Authorization().SubjectAccessReviews().Create(sar)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/oc/cli/cmd/observe/observe.go
+++ b/pkg/oc/cli/cmd/observe/observe.go
@@ -441,10 +441,12 @@ func (o *ObserveOptions) Run() error {
 	}
 
 	defer o.dumpMetrics()
+	stopChan := make(chan struct{})
+	defer close(stopChan)
 
 	// start the reflector
 	reflector := cache.NewNamedReflector("observer", lw, nil, store, o.resyncPeriod)
-	reflector.Run()
+	reflector.Run(stopChan)
 
 	if o.once {
 		// wait until the reflector reports it has completed the initial list and the
@@ -777,7 +779,7 @@ func (lw restListWatcher) List(opt metav1.ListOptions) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return lw.Helper.List(lw.namespace, "", labelSelector, false)
+	return lw.Helper.List(lw.namespace, "", labelSelector, false, false)
 }
 
 func (lw restListWatcher) Watch(opt metav1.ListOptions) (watch.Interface, error) {

--- a/pkg/oc/cli/cmd/rsh.go
+++ b/pkg/oc/cli/cmd/rsh.go
@@ -10,7 +10,7 @@ import (
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/term"
+	"k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"

--- a/pkg/oc/cli/cmd/rsync/forwarder.go
+++ b/pkg/oc/cli/cmd/rsync/forwarder.go
@@ -2,10 +2,11 @@ package rsync
 
 import (
 	"io"
+	"net/http"
 
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport/spdy"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -33,10 +34,9 @@ func (f *portForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) e
 		Name(f.PodName).
 		SubResource("portforward")
 
-	dialer, err := remotecommand.NewExecutor(f.Config, "POST", req.URL())
-	if err != nil {
-		return err
-	}
+	transport, upgrader, err := spdy.RoundTripperFor(f.Config)
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
 	// TODO: Make os.Stdout/Stderr configurable
 	readyChan := make(chan struct{})
 	fw, err := portforward.New(dialer, ports, stopChan, readyChan, f.Out, f.ErrOut)

--- a/pkg/oc/cli/cmd/wrappers.go
+++ b/pkg/oc/cli/cmd/wrappers.go
@@ -607,7 +607,7 @@ var (
 
 // NewCmdApply is a wrapper for the Kubernetes cli apply command
 func NewCmdApply(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdApply(f, out, errOut)
+	cmd := kcmd.NewCmdApply(fullName, f, out, errOut)
 	cmd.Long = applyLong
 	cmd.Example = fmt.Sprintf(applyExample, fullName)
 	return cmd

--- a/pkg/oc/cli/kubectl_compat_test.go
+++ b/pkg/oc/cli/kubectl_compat_test.go
@@ -36,6 +36,7 @@ var MissingCommands = sets.NewString(
 	"rollingupdate",
 	"run-container",
 	"update",
+	"alpha",
 )
 
 // WhitelistedCommands is the list of commands we're never going to have,

--- a/pkg/oc/cli/secrets/basicauth.go
+++ b/pkg/oc/cli/secrets/basicauth.go
@@ -12,7 +12,7 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	kterm "k8s.io/kubernetes/pkg/util/term"
+	kterm "k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	"github.com/openshift/origin/pkg/cmd/util/term"
 )

--- a/pkg/project/controller/project_finalizer_controller_test.go
+++ b/pkg/project/controller/project_finalizer_controller_test.go
@@ -9,7 +9,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 
 	projectapiv1 "github.com/openshift/origin/pkg/project/apis/project/v1"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestSyncNamespaceThatIsTerminating(t *testing.T) {

--- a/vendor/github.com/containers/image/signature/mechanism_gpgme.go
+++ b/vendor/github.com/containers/image/signature/mechanism_gpgme.go
@@ -1,4 +1,4 @@
-// +build !containers_image_openpgp
+// +build !containers_image_openpgp,linux,cgo
 
 package signature
 

--- a/vendor/github.com/containers/image/signature/mechanism_openpgp.go
+++ b/vendor/github.com/containers/image/signature/mechanism_openpgp.go
@@ -1,4 +1,4 @@
-// +build containers_image_openpgp
+// +build containers_image_openpgp !cgo !linux
 
 package signature
 

--- a/vendor/github.com/docker/distribution/registry/client/repository.go
+++ b/vendor/github.com/docker/distribution/registry/client/repository.go
@@ -670,7 +670,7 @@ func (bs *blobs) Put(ctx context.Context, mediaType string, p []byte) (distribut
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}
-	dgstr := digest.Canonical.New()
+	dgstr := digest.Canonical.Digester()
 	n, err := io.Copy(writer, io.TeeReader(bytes.NewReader(p), dgstr.Hash()))
 	if err != nil {
 		return distribution.Descriptor{}, err


### PR DESCRIPTION
@soltysh 

* `UPSTREAM: docker/distribution: 0000: fix initialization of Digester` - i guess this should go away when we outcast registry from origin repo? but i needed it to make sure pkg/oc builds and test properly.
* `fix forwarder` - probably need some second pair of eye if what I did is enough (seems like the executor is not needed according to upstream?)

The last commit is just mechanical and import moves. This make `pkg/oc` buildable and make the tests pass.