### PR TITLE
Serialization fixes

### DIFF
--- a/pkg/apps/apis/apps/v1/legacy.go
+++ b/pkg/apps/apis/apps/v1/legacy.go
@@ -1,0 +1,7 @@
+package v1
+
+func init() {
+	// TODO: Remove this once the legacy API will be deprecated. We need this now
+	// in order to make the serialization test pass.
+	LegacySchemeBuilder.Register(RegisterConversions)
+}

--- a/pkg/authorization/apis/authorization/v1/legacy.go
+++ b/pkg/authorization/apis/authorization/v1/legacy.go
@@ -1,0 +1,7 @@
+package v1
+
+func init() {
+	// TODO: Remove this once the legacy API will be deprecated. We need this now
+	// in order to make the serialization test pass.
+	LegacySchemeBuilder.Register(RegisterConversions)
+}


### PR DESCRIPTION
* First patch revert new k8s JSON encoder to standard Go library encoder until we figure out why it fails to decode `"\""` in DockerImage
* Second patch wraps the legacy and grouped scheme in order for both to have conversion functions