### PR TITLE
wire print flags in config/patch cmd

### DIFF
--- a/pkg/oc/cli/experimental/config/config.go
+++ b/pkg/oc/cli/experimental/config/config.go
@@ -20,7 +20,7 @@ func NewCmdConfig(name, fullName string, f kcmdutil.Factory, streams genericclio
 		Run:   kcmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
-	cmd.AddCommand(NewCmdPatch(PatchRecommendedName, fullName+" "+PatchRecommendedName, f, streams))
+	cmd.AddCommand(NewCmdPatch(PatchRecommendedName, f, streams))
 
 	return cmd
 }


### PR DESCRIPTION
cc @soltysh 

I think we actually want to drop this command, since we've successfully replaced all of its uses in Origin with the upstream `patch` command. cc @deads2k